### PR TITLE
Since sitemap reader servlet is in both dispatcher and front it makes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,10 @@ being generated automatically. As an alternative, the old approach on java inter
 supported, the equivalent are `NewsSitemapable` and `VideoSitemapable`.
 
 ## Upgrade notes
-1.5 SitemapReadServlet is now added as web-fragment. Remove the following rows from webapp-dispatcher and front web.xml if upgrading from previous version 
+
+#### 1.5 
+
+* SitemapReadServlet is now added as web-fragment. Remove the following rows from webapp-dispatcher and front web.xml if upgrading from previous version 
 
 ```
   <servlet>

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ supported, the equivalent are `NewsSitemapable` and `VideoSitemapable`.
 
 ## Upgrade notes
 
-#### 1.5 
+#### 1.2 
 
 * SitemapReadServlet is now added as web-fragment. Remove the following rows from webapp-dispatcher and front web.xml if upgrading from previous version 
 

--- a/README.md
+++ b/README.md
@@ -14,53 +14,9 @@ You will need to modify the webapp-dispatcher web.xml:
     <servlet-class>com.atex.plugins.sitemap.SitemapGeneratorServlet</servlet-class>
   </servlet>
 
-  <servlet>
-    <servlet-name>sitemapRead</servlet-name>
-    <servlet-class>com.atex.plugins.sitemap.SitemapReadServlet</servlet-class>
-  </servlet>
-
   <servlet-mapping>
     <servlet-name>sitemapGenerator</servlet-name>
     <url-pattern>/sitemapGenerator</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>sitemapRead</servlet-name>
-    <url-pattern>/sitemap.xml</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>sitemapRead</servlet-name>
-    <url-pattern>/sitemap_news.xml</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>sitemapRead</servlet-name>
-    <url-pattern>/sitemap_video.xml</url-pattern>
-  </servlet-mapping>
-```
-
-and the webapp-front web.xml:
-
-```
-  <servlet>
-    <servlet-name>sitemapRead</servlet-name>
-    <servlet-class>com.atex.plugins.sitemap.SitemapReadServlet</servlet-class>
-  </servlet>
-
-  <servlet-mapping>
-    <servlet-name>sitemapRead</servlet-name>
-    <url-pattern>/sitemap.xml</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>sitemapRead</servlet-name>
-    <url-pattern>/sitemap_news.xml</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>sitemapRead</servlet-name>
-    <url-pattern>/sitemap_video.xml</url-pattern>
   </servlet-mapping>
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,3 +149,29 @@ This plugins defines two variants: `NewsArticleSitemapBean` and `VideoSitemapBea
 You need to provide a mapper or a composer for such variants if you want to have the sitemap XML
 being generated automatically. As an alternative, the old approach on java interfaces is still
 supported, the equivalent are `NewsSitemapable` and `VideoSitemapable`.
+
+## Upgrade notes
+1.5 SitemapReadServlet is now added as web-fragment. Remove the following rows from webapp-dispatcher and front web.xml if upgrading from previous version 
+
+```
+  <servlet>
+    <servlet-name>sitemapRead</servlet-name>
+    <servlet-class>com.atex.plugins.sitemap.SitemapReadServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>sitemapRead</servlet-name>
+    <url-pattern>/sitemap.xml</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>sitemapRead</servlet-name>
+    <url-pattern>/sitemap_news.xml</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>sitemapRead</servlet-name>
+    <url-pattern>/sitemap_video.xml</url-pattern>
+  </servlet-mapping>
+```
+  

--- a/src/main/resources/META-INF/web-fragment.xml
+++ b/src/main/resources/META-INF/web-fragment.xml
@@ -28,4 +28,24 @@
     <param-value>sitemap_video.xml</param-value>
   </context-param>
 
+  <servlet>
+    <servlet-name>sitemapRead</servlet-name>
+    <servlet-class>com.atex.plugins.sitemap.SitemapReadServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>sitemapRead</servlet-name>
+    <url-pattern>/sitemap.xml</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>sitemapRead</servlet-name>
+    <url-pattern>/sitemap_news.xml</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>sitemapRead</servlet-name>
+    <url-pattern>/sitemap_video.xml</url-pattern>
+  </servlet-mapping>
+
 </web-fragment>


### PR DESCRIPTION
… it easier to configure if its added as web-fragment.xml

Probably existing users that upgrade would have the sitemap reader servlet added twice, once as described in previous README.md and by the added line in web-fragment.xml 